### PR TITLE
Retry delay randomized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+### Changed
+- Randomized the retry delay for trying to acquire the lock again (range between 0.1 and 0.3 seconds).
+
+## 0.0.1 - 2017-03-05
+### Added
+- aioredlock first version with all the basic distributed lock manager functionalities.


### PR DESCRIPTION
Random time set between 0.1 and 0.3 seconds. This will avoid 2 different clients fighting forever to acquire the lock on a instance.