### PR TITLE
Use attrs to allow more flexible parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,17 +45,23 @@ Usage
 How it works
 ------------
 
-The Aioredlock constructor takes a list of connections (host and port) where the Redis instances are running as a required parameter.
+The Aioredlock constructor accepts the following optional parameters:
+
+- ``redis_connections``: A list of connections (dictionary of host and port) where the Redis instances are running. The default value is ``[{'host': 'localhost', 'port': 6379}]``.
+- ``lock_timeout``: An integer (in milliseconds) representing lock validity period. The default value is ``10000`` ms.
+- ``drift``: An integer for clock drift compensation. The default value is calculated by ``int(lock_timeout * 0.01) + 2`` ms.
+- ``retry_count``: An integer representing number of maximum allowed retries to acquire the lock. The default value is ``3`` times.
+- ``retry_delay_min`` and ``retry_delay_max``: Float values representing waiting time (in seconds) before the next retry attempt. The default values are ``0.1`` and ``0.3``, respectively.
+
 In order to acquire the lock, the ``lock`` function should be called. If the lock operation is successful, ``lock.valid`` will be true.
 
-From that moment, the lock is valid until the ``unlock`` function is called or when the 10 seconds timeout is reached.
+From that moment, the lock is valid until the ``unlock`` function is called or when the ``lock_timeout`` is reached.
 
 In order to clear all the connections with Redis, the lock_manager ``destroy`` method can be called.
 
 To-do
 -----
 
-* Allow the user to set a desired lock timeout with 10 seconds default
 * Raise an exception if the lock cannot be obtained so no need to check for `lock.valid`
 * Handle/encapsulate aioredis exceptions when performing operations
 * Expire the lock valid attribute according to the lock validity in a safe way if possible

--- a/aioredlock/algorithm.py
+++ b/aioredlock/algorithm.py
@@ -17,9 +17,7 @@ def validate_lock_timeout(instance, attribute, value):
 
 @attr.s
 class Aioredlock:
-    redis_connections = attr.ib(
-        default=[{'host': 'localhost', 'port': 6379}]
-    )
+    redis_connections = attr.ib(default=[{'host': 'localhost', 'port': 6379}])
     lock_timeout = attr.ib(default=10000, convert=int, validator=validate_lock_timeout)
     # Proportional drift time to the length of the lock
     # See https://redis.io/topics/distlock#is-the-algorithm-asynchronous for more info

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 aioredis==0.3.1
+attrs==17.2.0

--- a/tests/ut/test_algorithm.py
+++ b/tests/ut/test_algorithm.py
@@ -25,10 +25,7 @@ def lock_manager_redis_patched():
             mock_redis.run_lua = CoroutineMock()
             mock_redis.clear_connections = CoroutineMock()
 
-            lock_manager = Aioredlock()
-            lock_manager.LOCK_TIMEOUT = 1000
-            lock_manager.retry_count = 3
-            lock_manager.drift = 102
+            lock_manager = Aioredlock(lock_timeout=1000, drift=102)
 
             yield lock_manager, mock_redis
 
@@ -42,7 +39,7 @@ class TestAioredlock:
 
             mock_redis.assert_called_once_with(
                 [{'host': 'localhost', 'port': 6379}],
-                lock_manager.LOCK_TIMEOUT
+                lock_manager.lock_timeout
             )
             assert lock_manager.redis
             assert lock_manager.drift == 102
@@ -54,7 +51,7 @@ class TestAioredlock:
 
             mock_redis.assert_called_once_with(
                 [{'host': '::1', 'port': 1}],
-                lock_manager.LOCK_TIMEOUT
+                lock_manager.lock_timeout
             )
             assert lock_manager.redis
             assert lock_manager.drift == 102


### PR DESCRIPTION
Fix #5.

Hi @joanvila,

I saw your issue ticket from `Hacktoberfest` tag. In this PR, I proposed to use [python-attrs/attrs](https://github.com/python-attrs/attrs) for configuring several parameters as an optional values. The benefit of using `attrs` is that you can configure validation rules for each parameter easier and it looks better IMO.

For example, all of the following constructors will work:

```
# Normal constructor
Aioredlock([{'host': 'localhost', 'port': 6379}])

# With lock timeout 1000 ms
Aioredlock([{'host': 'localhost', 'port': 6379}], 1000)

# Will also work because of convert=int handled by attrs
Aioredlock([{'host': 'localhost', 'port': 6379}], lock_timeout="1000") 

# Will throw ValueError("Lock timeout must be greater than 0 ms.")
Aioredlock([{'host': 'localhost', 'port': 6379}], lock_timeout="0")

# Set maximum retries count to 5 while using default value for other parameters
Aioredlock([{'host': 'localhost', 'port': 6379}], retry_count=5)
```

Please check it out, thanks 😃 