### PR TITLE
Allow to set db=N and password to redis client

### DIFF
--- a/aioredlock/redis.py
+++ b/aioredlock/redis.py
@@ -5,9 +5,11 @@ import time
 
 class Instance:
 
-    def __init__(self, host, port):
+    def __init__(self, host='localhost', port=6379, db=0, password=None):
         self.host = host
         self.port = port
+        self.db = db
+        self.password = password
 
         self._pool = None
         self._lock = asyncio.Lock()
@@ -20,7 +22,9 @@ class Instance:
             async with self._lock:
                 if self._pool is None:
                     self._pool = await aioredis.create_pool(
-                        (self.host, self.port), minsize=1, maxsize=100)
+                        (self.host, self.port),
+                        db=self.db, password=self.password,
+                        minsize=1, maxsize=100)
 
         return await self._pool
 
@@ -32,7 +36,7 @@ class Redis:
         self.instances = []
         for connection in redis_connections:
             self.instances.append(
-                Instance(connection['host'], connection['port']))
+                Instance(**connection))
 
         self.lock_timeout = lock_timeout
 

--- a/examples/basic_lock.py
+++ b/examples/basic_lock.py
@@ -5,7 +5,9 @@ from aioredlock import Aioredlock
 async def basic_lock():
     lock_manager = Aioredlock([{
         'host': 'localhost',
-        'port': 6379
+        'port': 6379,
+        'db': 0,
+        'password': None
     }])
 
     lock = await lock_manager.lock("resource")

--- a/tests/ut/test_redis.py
+++ b/tests/ut/test_redis.py
@@ -53,7 +53,10 @@ class TestInstance:
             assert instance._pool is None
             pool = await instance.connect()
 
-            create_pool.assert_called_once_with(('localhost', 6379), minsize=1, maxsize=100)
+            create_pool.assert_called_once_with(
+                ('localhost', 6379),
+                db=0, password=None,
+                minsize=1, maxsize=100)
             assert pool is fake_pool
             assert instance._pool is fake_pool
 
@@ -118,8 +121,8 @@ class TestRedis:
             redis = Redis(redis_two_connections, 10)
 
             calls = [
-                call('localhost', 6379),
-                call('127.0.0.1', 6378)
+                call(host='localhost', port=6379),
+                call(host='127.0.0.1', port=6378)
             ]
             mock_instance.assert_has_calls(calls)
             assert len(redis.instances) == 2


### PR DESCRIPTION
Connections list now accepts two more optional keys:
db and password.
All keys is potional even port can be omited.

Default values is:
    host='localhost'
    port=6379
    db=0
    password=None

Fixes #9