### PR TITLE
Potential Fix for #38

### DIFF
--- a/aioredlock/redis.py
+++ b/aioredlock/redis.py
@@ -316,3 +316,7 @@ class Redis:
                 tasks.append(i._pool.wait_closed())
         if tasks:
             await asyncio.gather(*tasks)
+
+        # Reset Pools after closed so can be re-used
+        for i in self.instances:
+            i._pool = None


### PR DESCRIPTION
This is a fix for #38 .

It now clears the pool, (not just disconnect) on destroy. This allows for next time we try to create a lock, the ability to re-connect again. The connection logic for acquiring a connection keys off is _pool is None. Before once an instance of Aioredlock was `destroy()` it was leaving everything in an un-useable state. I don't think there are any adverse affects, since this is just providing additional cleanup (not keeping around pools that no longer work).