### PR TITLE
Implement Instance.close() to close connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 .DS_Store
 *.swp
+.eggs/
 build/
 dist/
 *.egg-info/
@@ -16,3 +17,4 @@ __pycache__/
 
 .tox
 .cache
+.pytest_cache


### PR DESCRIPTION
Move all closing logic from Redis.clear_connections() to Instance.close().

Also fixes for new version of asynctest.