### PR TITLE
aioredlock: Fix for 89a1481872454710bd8a8bad2b1079d07b4d5af4:

### DIFF
--- a/aioredlock/redis.py
+++ b/aioredlock/redis.py
@@ -98,7 +98,6 @@ class Instance:
             redis_kwargs = kwargs
         elif isinstance(self.connection, aioredis.Redis):
             self._pool = self.connection
-            return self._pool
         else:
             # a tuple or list ('localhost', 6379)
             # a string "redis://host:6379/0?encoding=utf-8" or

--- a/tests/ut/test_redis.py
+++ b/tests/ut/test_redis.py
@@ -116,10 +116,8 @@ class TestInstance:
             redis_connection = await aioredis.create_redis_pool('redis://localhost')
             instance = Instance(redis_connection)
 
-            pool = await instance.connect()
-
+            await instance.connect()
             assert not create_redis_pool.called
-            assert pool is redis_connection
 
     @pytest.fixture
     def fake_instance(self):


### PR DESCRIPTION
We need to await the pool, just like before. Otherwise, we get:

```
Traceback (most recent call last):
  File "/ve/lib/python3.7/site-packages/aioredlock/redis.py", line 140, in set_lock
    with await self.connect() as redis:
AttributeError: __enter__
```