### PR TITLE
extend lock's lifetime automatically for 5 times 

### DIFF
--- a/examples/lock_context.py
+++ b/examples/lock_context.py
@@ -20,7 +20,11 @@ async def lock_context():
             assert lock.valid is True
             assert await lock_manager.is_locked("resource") is True
             # Do your stuff having the lock
-            await lock.extend()
+            await asyncio.sleep(lock_manager.lock_timeout)
+            # lock manager will extend the lock automatically
+            assert await lock_manager.is_locked(lock)
+            # or you can extend your lock's lifetime manually
+            await lock_manager.extend(lock)
             # Do more stuff having the lock
         assert lock.valid is False  # lock will be released by context manager
     except LockError:

--- a/tests/ut/test_algorithm.py
+++ b/tests/ut/test_algorithm.py
@@ -329,7 +329,7 @@ class TestAioredlock:
 
             await real_sleep(lock_manager.lock_timeout * 6)
 
-            calls = [call('resource', lock.id) for _ in range(10)]
+            calls = [call('resource', lock.id) for _ in range(lock_manager.auto_extend_count + 1)]
             mock_redis.set_lock.assert_has_calls(calls)
 
             await lock_manager.destroy()


### PR DESCRIPTION
#51  solved
Watchdog is added when a lock is created. It will wait for 0.6*lock_timeout and then entend the lock's lifetime for at most 5(default) times.
I think a good watchdog can：
      (a) automatically extend the lock's lifetime 
      (b) stop extending if the user spends too much more time than expected(w.r.t locked_timeout)
      (c) stop extending if the user's worker process failes 
      (d) stop extending if the user forget to unlock  
The watchdog I implemented can satisfy all the needs above 
test passed and examples works fine 