### PR TITLE
Enable Managing connections via Sentinels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,20 @@ syntax:
 	flake8
 
 ut:
-	coverage run -m pytest -sv tests/ut
+	coverage run -p -m pytest -v tests/ut
 
 acceptance:
-	pytest -sv tests/acceptance
+	coverage run -p -m pytest -v tests/acceptance
 
 all_tests: syntax ut acceptance coverage
 
 coverage:
+	coverage combine
 	coverage report
 	coverage xml
+
+clean:
+	find . -name \*.pyc -delete
+	find . -name __pycache__ -exec rmdir {} +
+	git checkout -- files/redis/sentinel.conf
+	coverage erase

--- a/README.rst
+++ b/README.rst
@@ -22,13 +22,15 @@ Usage
 -----
 .. code-block:: python
 
-  from aioredlock import Aioredlock, LockError
+  from aioredlock import Aioredlock, LockError, Sentinel
 
   # Define a list of connections to your Redis instances:
   redis_instances = [
     ('localhost', 6379),
     {'host': 'localhost', 'port': 6379, 'db': 1},
     'redis://localhost:6379/2',
+    Sentinel(('localhost', 26379), master='leader', db=3),
+    Sentinel('redis://:insecure@localhost:26379/4?master=leader&encoding=utf-8'),
   ]
 
   # Create a lock manager:

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,8 @@ Usage
     {'host': 'localhost', 'port': 6379, 'db': 1},
     'redis://localhost:6379/2',
     Sentinel(('localhost', 26379), master='leader', db=3),
-    Sentinel('redis://:insecure@localhost:26379/4?master=leader&encoding=utf-8'),
+    Sentinel('redis://localhost:26379/4?master=leader&encoding=utf-8'),
+    Sentinel('rediss://:password@localhost:26379/5?master=leader&encoding=utf-8&ssl_cert_reqs=CERT_NONE'),
   ]
 
   # Create a lock manager:

--- a/aioredlock/__init__.py
+++ b/aioredlock/__init__.py
@@ -1,9 +1,11 @@
 from aioredlock.algorithm import Aioredlock
 from aioredlock.errors import LockError
 from aioredlock.lock import Lock
+from aioredlock.sentinel import Sentinel
 
 __all__ = (
     'Aioredlock',
     'Lock',
-    'LockError'
+    'LockError',
+    'Sentinel'
 )

--- a/aioredlock/redis.py
+++ b/aioredlock/redis.py
@@ -110,12 +110,14 @@ class Instance:
             address = self.connection
 
         if self._pool is None:
+            if 'minsize' not in redis_kwargs:
+                redis_kwargs['minsize'] = 1
+            if 'maxsize' not in redis_kwargs:
+                redis_kwargs['maxsize'] = 100
             async with self._lock:
-                if self._pool is None:  # pragma no cover
+                if self._pool is None:
                     self.log.debug('Connecting %s', repr(self))
-                    self._pool = await self._create_redis_pool(
-                        address, **redis_kwargs,
-                        minsize=1, maxsize=100)
+                    self._pool = await self._create_redis_pool(address, **redis_kwargs)
 
         return await self._pool
 
@@ -123,7 +125,7 @@ class Instance:
         """
         Closes connection and resets pool
         """
-        if self._pool is not None and not isinstance(self.connection, aioredis.Redis):  # pragma no cover
+        if self._pool is not None and not isinstance(self.connection, aioredis.Redis):
             self._pool.close()
             await self._pool.wait_closed()
         self._pool = None

--- a/aioredlock/redis.py
+++ b/aioredlock/redis.py
@@ -7,6 +7,7 @@ from distutils.version import StrictVersion
 import aioredis
 
 from aioredlock.errors import LockError
+from aioredlock.sentinel import Sentinel
 
 
 class Instance:
@@ -44,6 +45,7 @@ class Instance:
                      'db': 0, 'password': 'pass'}
            all keys except host and port will be passed as kwargs to
            the aioredis.create_redis_pool();
+         * an aioredlock.redis.Sentinel object;
          * a Redis URI - "redis://host:6379/0?encoding=utf-8";
          * a (host, port) tuple - ('localhost', 6379);
          * or a unix domain socket path string - "/path/to/redis.sock".
@@ -86,8 +88,11 @@ class Instance:
         """
         Get an connection for the self instance
         """
+        address, redis_kwargs = (), {}
 
-        if isinstance(self.connection, dict):
+        if isinstance(self.connection, Sentinel):
+            self._pool = await self.connection.get_master()
+        elif isinstance(self.connection, dict):
             # a dict like {'host': 'localhost', 'port': 6379,
             #              'db': 0, 'password': 'pass'}
             kwargs = self.connection.copy()
@@ -103,11 +108,10 @@ class Instance:
             # a string "redis://host:6379/0?encoding=utf-8" or
             # a unix domain socket path "/path/to/redis.sock"
             address = self.connection
-            redis_kwargs = {}
 
         if self._pool is None:
             async with self._lock:
-                if self._pool is None:
+                if self._pool is None:  # pragma no cover
                     self.log.debug('Connecting %s', repr(self))
                     self._pool = await self._create_redis_pool(
                         address, **redis_kwargs,
@@ -119,7 +123,7 @@ class Instance:
         """
         Closes connection and resets pool
         """
-        if self._pool is not None and not isinstance(self.connection, aioredis.Redis):
+        if self._pool is not None and not isinstance(self.connection, aioredis.Redis):  # pragma no cover
             self._pool.close()
             await self._pool.wait_closed()
         self._pool = None
@@ -304,7 +308,7 @@ class Redis:
 
         self.log.debug('Clearing connection')
 
-        if self.instances:
+        if self.instances:  # pragma no cover
             await asyncio.gather(*(
                 i.close() for i in self.instances
             ))

--- a/aioredlock/sentinel.py
+++ b/aioredlock/sentinel.py
@@ -1,0 +1,98 @@
+import urllib.parse
+
+import aioredis.sentinel
+
+
+class SentinelConfigError(Exception):
+    '''
+    Exception raised if Configuration is not valid when instantiating a
+    Sentinel object.
+    '''
+
+
+class Sentinel:
+
+    def __init__(self, connection, master=None, password=None, db=None, ssl=None):
+        '''
+        The connection address can be one of the following:
+         * a dict - {'host': 'localhost', 'port': 6379}
+         * a Redis URI - "redis://host:6379/0?encoding=utf-8&master=mymaster";
+         * a (host, port) tuple - ('localhost', 6379);
+         * or a unix domain socket path string - "/path/to/redis.sock".
+         * a redis connection pool.
+
+        :param connection:
+            The connection address can be one of the following:
+                * a dict - {
+                    'host': 'localhost',
+                    'port': 26379,
+                    'password': 'insecure',
+                    'db': 0,
+                    'master': 'mymaster',
+                }
+                * a Redis URI - "redis://:insecure@host:26379/0?master=mymaster&encoding=utf-8";
+                * a (host, port) tuple - ('localhost', 26379);
+        :param master: The name of the master to connect to via the sentinel
+        :param password: The password to use to connect to the redis master
+        :param db: The db to use on the redis master
+
+        Explicitly specified parameters overwrite implicit options in the ``connection`` variable.
+
+        For example, if 'master' is specified in the connection dictionary,
+        but also specified as the master kwarg, the master kwarg will be used
+        instead.
+        '''
+        address, kwargs = (), {'ssl': ssl}
+        if isinstance(connection, dict):
+            kwargs.update(connection)
+            address = [(kwargs.pop('host'), kwargs.pop('port', 26379))]
+        elif isinstance(connection, str) and connection.startswith('redis://'):
+            url = urllib.parse.urlparse(connection)
+            address = [(url.hostname, url.port)]
+            dbnum = url.path.strip('/')
+
+            if dbnum.isdigit():
+                kwargs['db'] = int(dbnum)
+            else:
+                kwargs['db'] = 0
+
+            kwargs['password'] = url.password
+
+            kwargs.update({key: value[0] for key, value in urllib.parse.parse_qs(url.query).items()})
+        elif isinstance(connection, tuple):
+            address = [connection]
+        elif isinstance(connection, list):
+            address = connection
+        else:
+            raise SentinelConfigError('Invalid Sentinel Configuration')
+
+        if db is not None:
+            kwargs['db'] = db
+        if password is not None:
+            kwargs['password'] = password
+
+        self.master = kwargs.pop('master', None)
+        if master:
+            self.master = master
+
+        if self.master is None:
+            raise SentinelConfigError('Master name required for sentinel to be configured')
+
+        self.connection = address
+        self.redis_kwargs = kwargs
+
+    async def get_sentinel(self):
+        '''
+        Retrieve sentinel object from aioredis.
+        '''
+        return await aioredis.sentinel.create_sentinel(
+            sentinels=self.connection,
+            **self.redis_kwargs,
+        )
+
+    async def get_master(self):
+        '''
+        Get ``Redis`` instance for specified ``master``
+        '''
+        sentinel = await self.get_sentinel()
+        return await sentinel.master_for(self.master)

--- a/aioredlock/sentinel.py
+++ b/aioredlock/sentinel.py
@@ -37,6 +37,9 @@ class Sentinel:
         :param master: The name of the master to connect to via the sentinel
         :param password: The password to use to connect to the redis master
         :param db: The db to use on the redis master
+        :param ssl_context: The ssl context to assign to the redis connection.
+            If ssl_context is ``True``, the default ssl context in python will be assigned, otherwise
+            an ssl context must be provided.
 
         Explicitly specified parameters overwrite implicit options in the ``connection`` variable.
 
@@ -48,7 +51,7 @@ class Sentinel:
         if isinstance(connection, dict):
             kwargs.update(connection)
             address = [(kwargs.pop('host'), kwargs.pop('port', 26379))]
-        elif isinstance(connection, str) and re.match(r'^rediss?://.*\:\d+/\d\??.*$', connection):
+        elif isinstance(connection, str) and re.match(r'^rediss?://.*\:\d+/\d?\??.*$', connection):
             url = urllib.parse.urlparse(connection)
             query = {key: value[0] for key, value in urllib.parse.parse_qs(url.query).items()}
             address = [(url.hostname, url.port or 6379)]
@@ -77,7 +80,9 @@ class Sentinel:
             kwargs['db'] = db
         if password is not None:
             kwargs['password'] = password
-        if ssl_context is not None:
+        if ssl_context is True:
+            kwargs['ssl'] = ssl.create_default_context()
+        elif ssl_context is not None:
             kwargs['ssl'] = ssl_context
 
         self.master = kwargs.pop('master', None)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  leader:
+    container_name: leader
+    image: redis
+    ports:
+    - 6379
+    networks:
+    - backend
+  follower:
+    container_name: follower
+    image: redis
+    ports:
+    - 6379
+    networks:
+    - backend
+    command: ["--replicaof", "leader", "6379"]
+  sentinel:
+    container_name: sentinel
+    image: redis
+    ports:
+    - 26379
+    command: ["/etc/redis/sentinel.conf", "--sentinel"]
+    networks:
+    - backend
+    volumes:
+    - ./files/redis/sentinel.conf:/etc/redis/sentinel.conf
+
+networks:
+  backend:
+    driver: bridge

--- a/files/redis/sentinel.conf
+++ b/files/redis/sentinel.conf
@@ -1,0 +1,3 @@
+port 26379
+sentinel monitor leader leader 6379 2
+sentinel down-after-milliseconds leader 5000

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,12 @@ test=pytest
 
 [bdist_wheel]
 universal = 1
+
+[tool:pytest]
+addopts = -ra
+log_cli_level = critical
+junit_family = xunit2
+testpaths = tests/
+norecursedirs = .git .tox
+filterwarnings =
+  ignore::DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
 
     install_requires=['aioredis', 'attrs >= 17.4.0'],
     extras_require={
-        'test': ['pytest', 'pytest-asyncio', 'pytest-mock', 'pytest-cov', 'asynctest', 'flake8'],
+        'test': ['pytest', 'pytest-asyncio', 'pytest-mock', 'pytest-cov', 'asynctest', 'flake8', 'docker'],
         'cicd': ['codecov'],
         'package': ['bump2version', 'twine', 'wheel'],
     },

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -1,4 +1,6 @@
+import ssl
 import uuid
+import unittest.mock
 
 import asynctest
 import pytest
@@ -47,3 +49,10 @@ def aioredlock_patched():
             mock_aioredlock.destroy = CoroutineMock()
 
             yield mock_aioredlock
+
+
+@pytest.fixture
+def ssl_context():
+    context = ssl.create_default_context()
+    with unittest.mock.patch('ssl.create_default_context', return_value=context):
+        yield context

--- a/tests/ut/test_redis.py
+++ b/tests/ut/test_redis.py
@@ -97,6 +97,25 @@ class TestInstance:
             assert instance._pool is fake_pool
 
     @pytest.mark.asyncio
+    async def test_connect_pool_not_created_with_minsize_and_maxsize(self):
+        connection = {'host': 'localhost', 'port': 6379, 'db': 0, 'password': 'pass', 'minsize': 2, 'maxsize': 5}
+        address = ('localhost', 6379)
+        redis_kwargs = {'db': 0, 'password': 'pass'}
+        with patch('aioredlock.redis.Instance._create_redis_pool') as \
+                create_redis_pool:
+
+            fake_pool = FakePool()
+            create_redis_pool.side_effect = fake_create_redis_pool(fake_pool)
+            instance = Instance(connection)
+
+            assert instance._pool is None
+            pool = await instance.connect()
+
+            create_redis_pool.assert_called_once_with(address, **redis_kwargs, minsize=2, maxsize=5)
+            assert pool is fake_pool
+            assert instance._pool is fake_pool
+
+    @pytest.mark.asyncio
     async def test_connect_pool_already_created(self):
 
         with patch('aioredlock.redis.Instance._create_redis_pool') as \

--- a/tests/ut/test_sentinel.py
+++ b/tests/ut/test_sentinel.py
@@ -31,200 +31,137 @@ def mock_aioredis_sentinel():
         yield mock_sentinel
 
 
-async def test_sentinel_dict():
-    with mock_aioredis_sentinel() as mock_sentinel:
-        sentinel = Sentinel({
-            'host': '127.0.0.1',
-            'port': 26379,
-            'master': 'leader',
-        })
-        assert await sentinel.get_master()
-    assert mock_sentinel.called
-    mock_sentinel.assert_called_with(sentinels=[('127.0.0.1', 26379)], minsize=1, maxsize=100)
-    if sys.version_info < (3, 8, 0):
-        result = mock_sentinel.return_value.result()
-    else:
-        result = mock_sentinel.return_value
-    assert result.master_for.called
-    result.master_for.assert_called_with('leader')
-
-
-async def test_sentinel_str():
-    with mock_aioredis_sentinel() as mock_sentinel:
-        sentinel = Sentinel(
-            'redis://:password@localhost:12345/0?master=whatever&encoding=utf-8&minsize=2&maxsize=5'
-        )
-        assert await sentinel.get_master()
-    assert mock_sentinel.called
-    mock_sentinel.assert_called_with(
-        sentinels=[('localhost', 12345)],
-        db=0,
-        encoding='utf-8',
-        password='password',
-        minsize=2,
-        maxsize=5
-    )
-    if sys.version_info < (3, 8, 0):
-        result = mock_sentinel.return_value.result()
-    else:
-        result = mock_sentinel.return_value
-    assert result.master_for.called
-    result.master_for.assert_called_with('whatever')
-
-
-async def test_sentinel_str_overrides():
-    with mock_aioredis_sentinel() as mock_sentinel:
-        sentinel = Sentinel(
+@pytest.mark.parametrize(
+    'connection,kwargs,expected_kwargs,expected_master,with_ssl', (
+        (
+            {'host': '127.0.0.1', 'port': 26379, 'master': 'leader'},
+            {},
+            {'sentinels': [('127.0.0.1', 26379)], 'minsize': 1, 'maxsize': 100},
+            'leader',
+            {},
+        ),
+        (
+            'redis://:password@localhost:12345/0?master=whatever&encoding=utf-8&minsize=2&maxsize=5',
+            {},
+            {
+                'sentinels': [('localhost', 12345)],
+                'db': 0,
+                'encoding': 'utf-8',
+                'password': 'password',
+                'minsize': 2,
+                'maxsize': 5,
+            },
+            'whatever',
+            {},
+        ),
+        (
             'redis://:password@localhost:12345/0?master=whatever&encoding=utf-8',
-            master='everything',
-            password='newpass',
-            db=3,
-        )
-        assert await sentinel.get_master()
-    assert mock_sentinel.called
-    mock_sentinel.assert_called_with(
-        sentinels=[('localhost', 12345)],
-        db=3,
-        encoding='utf-8',
-        password='newpass',
-        minsize=1,
-        maxsize=100
-    )
-    if sys.version_info < (3, 8, 0):
-        result = mock_sentinel.return_value.result()
-    else:
-        result = mock_sentinel.return_value
-    assert result.master_for.called
-    result.master_for.assert_called_with('everything')
-
-
-async def test_sentinel_str_ssl_default(ssl_context):
-    with mock_aioredis_sentinel() as mock_sentinel:
-        sentinel = Sentinel('rediss://:password@localhost:12345/2?master=whatever&encoding=utf-8')
-        assert await sentinel.get_master()
-    assert mock_sentinel.called
-    mock_sentinel.assert_called_with(
-        sentinels=[('localhost', 12345)],
-        db=2,
-        encoding='utf-8',
-        password='password',
-        minsize=1,
-        maxsize=100,
-        ssl=ssl_context
-    )
-    if sys.version_info < (3, 8, 0):
-        result = mock_sentinel.return_value.result()
-    else:
-        result = mock_sentinel.return_value
-    assert result.master_for.called
-    result.master_for.assert_called_with('whatever')
-    assert ssl_context.check_hostname is True
-    assert ssl_context.verify_mode is ssl.CERT_REQUIRED
-
-
-async def test_sentinel_str_ssl():
-    ssl_context = ssl.create_default_context()
-    with mock_aioredis_sentinel() as mock_sentinel, \
-            mock.patch('ssl.create_default_context', return_value=ssl_context):
-        sentinel = Sentinel(
-            'rediss://:password@localhost:12345/2?'
-            'master=whatever&encoding=utf-8&ssl_cert_reqs=CERT_NONE',
-        )
-        assert await sentinel.get_master()
-    assert mock_sentinel.called
-    mock_sentinel.assert_called_with(
-        sentinels=[('localhost', 12345)],
-        db=2,
-        encoding='utf-8',
-        password='password',
-        minsize=1,
-        maxsize=100,
-        ssl=ssl_context
-    )
-    if sys.version_info < (3, 8, 0):
-        result = mock_sentinel.return_value.result()
-    else:
-        result = mock_sentinel.return_value
-    assert result.master_for.called
-    result.master_for.assert_called_with('whatever')
-    assert ssl_context.check_hostname is False
-    assert ssl_context.verify_mode is ssl.CERT_NONE
-
-
-async def test_sentinel_str_ssl_cert_optional():
-    ssl_context = ssl.create_default_context()
-    with mock_aioredis_sentinel() as mock_sentinel, \
-            mock.patch('ssl.create_default_context', return_value=ssl_context):
-        sentinel = Sentinel(
-            'rediss://:password@localhost:12345/2?'
-            'master=whatever&encoding=utf-8&ssl_cert_reqs=CERT_OPTIONAL',
-        )
-        assert await sentinel.get_master()
-    assert mock_sentinel.called
-    mock_sentinel.assert_called_with(
-        sentinels=[('localhost', 12345)],
-        db=2,
-        encoding='utf-8',
-        password='password',
-        minsize=1,
-        maxsize=100,
-        ssl=ssl_context
-    )
-    if sys.version_info < (3, 8, 0):
-        result = mock_sentinel.return_value.result()
-    else:
-        result = mock_sentinel.return_value
-    assert result.master_for.called
-    result.master_for.assert_called_with('whatever')
-    assert ssl_context.check_hostname is True
-    assert ssl_context.verify_mode is ssl.CERT_OPTIONAL
-
-
-async def test_sentinel_tuple():
-    with mock_aioredis_sentinel() as mock_sentinel:
-        sentinel = Sentinel(
+            {'master': 'everything', 'password': 'newpass', 'db': 3},
+            {
+                'sentinels': [('localhost', 12345)],
+                'db': 3,
+                'encoding': 'utf-8',
+                'password': 'newpass',
+                'minsize': 1,
+                'maxsize': 100,
+            },
+            'everything',
+            {},
+        ),
+        (
+            'rediss://:password@localhost:12345/2?master=whatever&encoding=utf-8',
+            {},
+            {
+                'sentinels': [('localhost', 12345)],
+                'db': 2,
+                'encoding': 'utf-8',
+                'password': 'password',
+                'minsize': 1,
+                'maxsize': 100,
+            },
+            'whatever',
+            {'verify_mode': ssl.CERT_REQUIRED, 'check_hostname': True},
+        ),
+        (
+            'rediss://:password@localhost:12345/2?master=whatever&encoding=utf-8&ssl_cert_reqs=CERT_NONE',
+            {},
+            {
+                'sentinels': [('localhost', 12345)],
+                'db': 2,
+                'encoding': 'utf-8',
+                'password': 'password',
+                'minsize': 1,
+                'maxsize': 100,
+            },
+            'whatever',
+            {'verify_mode': ssl.CERT_NONE, 'check_hostname': False},
+        ),
+        (
+            'rediss://localhost:12345/2?master=whatever&encoding=utf-8&ssl_cert_reqs=CERT_OPTIONAL',
+            {},
+            {
+                'sentinels': [('localhost', 12345)],
+                'db': 2,
+                'encoding': 'utf-8',
+                'password': None,
+                'minsize': 1,
+                'maxsize': 100,
+            },
+            'whatever',
+            {'verify_mode': ssl.CERT_OPTIONAL, 'check_hostname': True},
+        ),
+        (
             ('127.0.0.1', 1234),
-            master='blah',
-            ssl_context=False,
-        )
-        assert await sentinel.get_master()
-    assert mock_sentinel.called
-    mock_sentinel.assert_called_with(sentinels=[('127.0.0.1', 1234)], ssl=False, minsize=1, maxsize=100)
-    if sys.version_info < (3, 8, 0):
-        result = mock_sentinel.return_value.result()
-    else:
-        result = mock_sentinel.return_value
-    assert result.master_for.called
-    result.master_for.assert_called_with('blah')
-
-
-async def test_sentinel_list():
-    with mock_aioredis_sentinel() as mock_sentinel:
-        sentinel = Sentinel(
+            {'master': 'blah', 'ssl_context': True},
+            {
+                'sentinels': [('127.0.0.1', 1234)],
+                'minsize': 1,
+                'maxsize': 100,
+            },
+            'blah',
+            {},
+        ),
+        (
             [('127.0.0.1', 1234), ('blah', 4829)],
-            master='blah',
-        )
+            {'master': 'blah', 'ssl_context': False},
+            {
+                'sentinels': [('127.0.0.1', 1234), ('blah', 4829)],
+                'minsize': 1,
+                'maxsize': 100,
+                'ssl': False,
+            },
+            'blah',
+            {},
+        ),
+    )
+)
+async def test_sentinel(ssl_context, connection, kwargs, expected_kwargs, expected_master, with_ssl):
+    with mock_aioredis_sentinel() as mock_sentinel:
+        sentinel = Sentinel(connection, **kwargs)
         assert await sentinel.get_master()
     assert mock_sentinel.called
-    mock_sentinel.assert_called_with(sentinels=[('127.0.0.1', 1234), ('blah', 4829)], minsize=1, maxsize=100)
+    if with_ssl or kwargs.get('ssl_context') is True:
+        expected_kwargs['ssl'] = ssl_context
+    mock_sentinel.assert_called_with(**expected_kwargs)
     if sys.version_info < (3, 8, 0):
         result = mock_sentinel.return_value.result()
     else:
         result = mock_sentinel.return_value
     assert result.master_for.called
-    result.master_for.assert_called_with('blah')
+    result.master_for.assert_called_with(expected_master)
+    if with_ssl:
+        assert ssl_context.check_hostname is with_ssl['check_hostname']
+        assert ssl_context.verify_mode is with_ssl['verify_mode']
 
 
-async def test_sentinel_no_master_specified():
+@pytest.mark.parametrize(
+    'connection',
+    (
+        'redis://localhost:1234/0',
+        'redis://localhost:1234/blah',
+        object(),
+    )
+)
+async def test_sentinel_config_errors(connection):
     with pytest.raises(SentinelConfigError):
-        Sentinel('redis://localhost:1234/0')
-
-
-async def test_sentinel_bad_database():
-    with pytest.raises(SentinelConfigError):
-        Sentinel('redis://localhost:1234/blah')
-
-
-async def test_sentinel_invalid_connection():
-    with pytest.raises(SentinelConfigError):
-        Sentinel(object())
+        Sentinel(connection)

--- a/tests/ut/test_sentinel.py
+++ b/tests/ut/test_sentinel.py
@@ -39,13 +39,13 @@ async def test_sentinel_dict():
             'master': 'leader',
         })
         assert await sentinel.get_master()
-    mock_sentinel.assert_called()
+    assert mock_sentinel.called
     mock_sentinel.assert_called_with(sentinels=[('127.0.0.1', 26379)], minsize=1, maxsize=100)
     if sys.version_info < (3, 8, 0):
         result = mock_sentinel.return_value.result()
     else:
         result = mock_sentinel.return_value
-    result.master_for.assert_called()
+    assert result.master_for.called
     result.master_for.assert_called_with('leader')
 
 
@@ -55,7 +55,7 @@ async def test_sentinel_str():
             'redis://:password@localhost:12345/0?master=whatever&encoding=utf-8&minsize=2&maxsize=5'
         )
         assert await sentinel.get_master()
-    mock_sentinel.assert_called()
+    assert mock_sentinel.called
     mock_sentinel.assert_called_with(
         sentinels=[('localhost', 12345)],
         db=0,
@@ -68,7 +68,7 @@ async def test_sentinel_str():
         result = mock_sentinel.return_value.result()
     else:
         result = mock_sentinel.return_value
-    result.master_for.assert_called()
+    assert result.master_for.called
     result.master_for.assert_called_with('whatever')
 
 
@@ -81,7 +81,7 @@ async def test_sentinel_str_overrides():
             db=3,
         )
         assert await sentinel.get_master()
-    mock_sentinel.assert_called()
+    assert mock_sentinel.called
     mock_sentinel.assert_called_with(
         sentinels=[('localhost', 12345)],
         db=3,
@@ -94,7 +94,7 @@ async def test_sentinel_str_overrides():
         result = mock_sentinel.return_value.result()
     else:
         result = mock_sentinel.return_value
-    result.master_for.assert_called()
+    assert result.master_for.called
     result.master_for.assert_called_with('everything')
 
 
@@ -102,7 +102,7 @@ async def test_sentinel_str_ssl_default(ssl_context):
     with mock_aioredis_sentinel() as mock_sentinel:
         sentinel = Sentinel('rediss://:password@localhost:12345/2?master=whatever&encoding=utf-8')
         assert await sentinel.get_master()
-    mock_sentinel.assert_called()
+    assert mock_sentinel.called
     mock_sentinel.assert_called_with(
         sentinels=[('localhost', 12345)],
         db=2,
@@ -116,7 +116,7 @@ async def test_sentinel_str_ssl_default(ssl_context):
         result = mock_sentinel.return_value.result()
     else:
         result = mock_sentinel.return_value
-    result.master_for.assert_called()
+    assert result.master_for.called
     result.master_for.assert_called_with('whatever')
     assert ssl_context.check_hostname is True
     assert ssl_context.verify_mode is ssl.CERT_REQUIRED
@@ -131,7 +131,7 @@ async def test_sentinel_str_ssl():
             'master=whatever&encoding=utf-8&ssl_cert_reqs=CERT_NONE',
         )
         assert await sentinel.get_master()
-    mock_sentinel.assert_called()
+    assert mock_sentinel.called
     mock_sentinel.assert_called_with(
         sentinels=[('localhost', 12345)],
         db=2,
@@ -145,7 +145,7 @@ async def test_sentinel_str_ssl():
         result = mock_sentinel.return_value.result()
     else:
         result = mock_sentinel.return_value
-    result.master_for.assert_called()
+    assert result.master_for.called
     result.master_for.assert_called_with('whatever')
     assert ssl_context.check_hostname is False
     assert ssl_context.verify_mode is ssl.CERT_NONE
@@ -160,7 +160,7 @@ async def test_sentinel_str_ssl_cert_optional():
             'master=whatever&encoding=utf-8&ssl_cert_reqs=CERT_OPTIONAL',
         )
         assert await sentinel.get_master()
-    mock_sentinel.assert_called()
+    assert mock_sentinel.called
     mock_sentinel.assert_called_with(
         sentinels=[('localhost', 12345)],
         db=2,
@@ -174,7 +174,7 @@ async def test_sentinel_str_ssl_cert_optional():
         result = mock_sentinel.return_value.result()
     else:
         result = mock_sentinel.return_value
-    result.master_for.assert_called()
+    assert result.master_for.called
     result.master_for.assert_called_with('whatever')
     assert ssl_context.check_hostname is True
     assert ssl_context.verify_mode is ssl.CERT_OPTIONAL
@@ -188,13 +188,13 @@ async def test_sentinel_tuple():
             ssl_context=False,
         )
         assert await sentinel.get_master()
-    mock_sentinel.assert_called()
+    assert mock_sentinel.called
     mock_sentinel.assert_called_with(sentinels=[('127.0.0.1', 1234)], ssl=False, minsize=1, maxsize=100)
     if sys.version_info < (3, 8, 0):
         result = mock_sentinel.return_value.result()
     else:
         result = mock_sentinel.return_value
-    result.master_for.assert_called()
+    assert result.master_for.called
     result.master_for.assert_called_with('blah')
 
 
@@ -205,13 +205,13 @@ async def test_sentinel_list():
             master='blah',
         )
         assert await sentinel.get_master()
-    mock_sentinel.assert_called()
+    assert mock_sentinel.called
     mock_sentinel.assert_called_with(sentinels=[('127.0.0.1', 1234), ('blah', 4829)], minsize=1, maxsize=100)
     if sys.version_info < (3, 8, 0):
         result = mock_sentinel.return_value.result()
     else:
         result = mock_sentinel.return_value
-    result.master_for.assert_called()
+    assert result.master_for.called
     result.master_for.assert_called_with('blah')
 
 

--- a/tests/ut/test_sentinel.py
+++ b/tests/ut/test_sentinel.py
@@ -1,0 +1,139 @@
+import asyncio
+import contextlib
+import sys
+from unittest import mock
+
+import aioredlock.sentinel
+from aioredlock.sentinel import Sentinel
+from aioredlock.sentinel import SentinelConfigError
+
+import pytest
+
+pytestmark = [pytest.mark.asyncio]
+
+
+@contextlib.contextmanager
+def mock_aioredis_sentinel():
+    if sys.version_info < (3, 8, 0):
+        mock_obj = mock.MagicMock()
+        mock_obj.master_for.return_value = asyncio.Future()
+        mock_obj.master_for.return_value.set_result(True)
+    else:
+        mock_obj = mock.AsyncMock()
+        mock_obj.master_for.return_value = True
+    with mock.patch.object(aioredlock.sentinel.aioredis.sentinel, 'create_sentinel') as mock_sentinel:
+        if sys.version_info < (3, 8, 0):
+            mock_sentinel.return_value = asyncio.Future()
+            mock_sentinel.return_value.set_result(mock_obj)
+        else:
+            mock_sentinel.return_value = mock_obj
+        yield mock_sentinel
+
+
+async def test_sentinel_dict():
+    with mock_aioredis_sentinel() as mock_sentinel:
+        sentinel = Sentinel({
+            'host': '127.0.0.1',
+            'port': 26379,
+            'master': 'leader',
+        })
+        assert await sentinel.get_master()
+    assert mock_sentinel.called
+    mock_sentinel.assert_called_with(sentinels=[('127.0.0.1', 26379)], ssl=None)
+    if sys.version_info < (3, 8, 0):
+        result = mock_sentinel.return_value.result()
+    else:
+        result = mock_sentinel.return_value
+    assert result.master_for.called
+    result.master_for.assert_called_with('leader')
+
+
+async def test_sentinel_str():
+    with mock_aioredis_sentinel() as mock_sentinel:
+        sentinel = Sentinel(
+            'redis://:password@localhost:12345/blah?master=whatever&encoding=utf-8'
+        )
+        assert await sentinel.get_master()
+    assert mock_sentinel.called
+    mock_sentinel.assert_called_with(
+        sentinels=[('localhost', 12345)],
+        ssl=None,
+        db=0,
+        encoding='utf-8',
+        password='password',
+    )
+    if sys.version_info < (3, 8, 0):
+        result = mock_sentinel.return_value.result()
+    else:
+        result = mock_sentinel.return_value
+    assert result.master_for.called
+    result.master_for.assert_called_with('whatever')
+
+
+async def test_sentinel_str_overrides():
+    with mock_aioredis_sentinel() as mock_sentinel:
+        sentinel = Sentinel(
+            'redis://:password@localhost:12345/0?master=whatever&encoding=utf-8',
+            master='everything',
+            password='newpass',
+            db=3,
+        )
+        assert await sentinel.get_master()
+    assert mock_sentinel.called
+    mock_sentinel.assert_called_with(
+        sentinels=[('localhost', 12345)],
+        ssl=None,
+        db=3,
+        encoding='utf-8',
+        password='newpass',
+    )
+    if sys.version_info < (3, 8, 0):
+        result = mock_sentinel.return_value.result()
+    else:
+        result = mock_sentinel.return_value
+    assert result.master_for.called
+    result.master_for.assert_called_with('everything')
+
+
+async def test_sentinel_tuple():
+    with mock_aioredis_sentinel() as mock_sentinel:
+        sentinel = Sentinel(
+            ('127.0.0.1', 1234),
+            master='blah',
+        )
+        assert await sentinel.get_master()
+    assert mock_sentinel.called
+    mock_sentinel.assert_called_with(sentinels=[('127.0.0.1', 1234)], ssl=None)
+    if sys.version_info < (3, 8, 0):
+        result = mock_sentinel.return_value.result()
+    else:
+        result = mock_sentinel.return_value
+    assert result.master_for.called
+    result.master_for.assert_called_with('blah')
+
+
+async def test_sentinel_list():
+    with mock_aioredis_sentinel() as mock_sentinel:
+        sentinel = Sentinel(
+            [('127.0.0.1', 1234), ('blah', 4829)],
+            master='blah',
+        )
+        assert await sentinel.get_master()
+    assert mock_sentinel.called
+    mock_sentinel.assert_called_with(sentinels=[('127.0.0.1', 1234), ('blah', 4829)], ssl=None)
+    if sys.version_info < (3, 8, 0):
+        result = mock_sentinel.return_value.result()
+    else:
+        result = mock_sentinel.return_value
+    assert result.master_for.called
+    result.master_for.assert_called_with('blah')
+
+
+async def test_sentinel_no_master_specified():
+    with pytest.raises(SentinelConfigError):
+        Sentinel('redis://localhost:1234/0')
+
+
+async def test_sentinel_invalid_connection():
+    with pytest.raises(SentinelConfigError):
+        Sentinel(object())

--- a/tests/ut/test_sentinel.py
+++ b/tests/ut/test_sentinel.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import ssl
 import sys
 from unittest import mock
 
@@ -38,35 +39,36 @@ async def test_sentinel_dict():
             'master': 'leader',
         })
         assert await sentinel.get_master()
-    assert mock_sentinel.called
-    mock_sentinel.assert_called_with(sentinels=[('127.0.0.1', 26379)], ssl=None)
+    mock_sentinel.assert_called()
+    mock_sentinel.assert_called_with(sentinels=[('127.0.0.1', 26379)], minsize=1, maxsize=100)
     if sys.version_info < (3, 8, 0):
         result = mock_sentinel.return_value.result()
     else:
         result = mock_sentinel.return_value
-    assert result.master_for.called
+    result.master_for.assert_called()
     result.master_for.assert_called_with('leader')
 
 
 async def test_sentinel_str():
     with mock_aioredis_sentinel() as mock_sentinel:
         sentinel = Sentinel(
-            'redis://:password@localhost:12345/blah?master=whatever&encoding=utf-8'
+            'redis://:password@localhost:12345/0?master=whatever&encoding=utf-8&minsize=2&maxsize=5'
         )
         assert await sentinel.get_master()
-    assert mock_sentinel.called
+    mock_sentinel.assert_called()
     mock_sentinel.assert_called_with(
         sentinels=[('localhost', 12345)],
-        ssl=None,
         db=0,
         encoding='utf-8',
         password='password',
+        minsize=2,
+        maxsize=5
     )
     if sys.version_info < (3, 8, 0):
         result = mock_sentinel.return_value.result()
     else:
         result = mock_sentinel.return_value
-    assert result.master_for.called
+    result.master_for.assert_called()
     result.master_for.assert_called_with('whatever')
 
 
@@ -79,20 +81,103 @@ async def test_sentinel_str_overrides():
             db=3,
         )
         assert await sentinel.get_master()
-    assert mock_sentinel.called
+    mock_sentinel.assert_called()
     mock_sentinel.assert_called_with(
         sentinels=[('localhost', 12345)],
-        ssl=None,
         db=3,
         encoding='utf-8',
         password='newpass',
+        minsize=1,
+        maxsize=100
     )
     if sys.version_info < (3, 8, 0):
         result = mock_sentinel.return_value.result()
     else:
         result = mock_sentinel.return_value
-    assert result.master_for.called
+    result.master_for.assert_called()
     result.master_for.assert_called_with('everything')
+
+
+async def test_sentinel_str_ssl_default(ssl_context):
+    with mock_aioredis_sentinel() as mock_sentinel:
+        sentinel = Sentinel('rediss://:password@localhost:12345/2?master=whatever&encoding=utf-8')
+        assert await sentinel.get_master()
+    mock_sentinel.assert_called()
+    mock_sentinel.assert_called_with(
+        sentinels=[('localhost', 12345)],
+        db=2,
+        encoding='utf-8',
+        password='password',
+        minsize=1,
+        maxsize=100,
+        ssl=ssl_context
+    )
+    if sys.version_info < (3, 8, 0):
+        result = mock_sentinel.return_value.result()
+    else:
+        result = mock_sentinel.return_value
+    result.master_for.assert_called()
+    result.master_for.assert_called_with('whatever')
+    assert ssl_context.check_hostname is True
+    assert ssl_context.verify_mode is ssl.CERT_REQUIRED
+
+
+async def test_sentinel_str_ssl():
+    ssl_context = ssl.create_default_context()
+    with mock_aioredis_sentinel() as mock_sentinel, \
+            mock.patch('ssl.create_default_context', return_value=ssl_context):
+        sentinel = Sentinel(
+            'rediss://:password@localhost:12345/2?'
+            'master=whatever&encoding=utf-8&ssl_cert_reqs=CERT_NONE',
+        )
+        assert await sentinel.get_master()
+    mock_sentinel.assert_called()
+    mock_sentinel.assert_called_with(
+        sentinels=[('localhost', 12345)],
+        db=2,
+        encoding='utf-8',
+        password='password',
+        minsize=1,
+        maxsize=100,
+        ssl=ssl_context
+    )
+    if sys.version_info < (3, 8, 0):
+        result = mock_sentinel.return_value.result()
+    else:
+        result = mock_sentinel.return_value
+    result.master_for.assert_called()
+    result.master_for.assert_called_with('whatever')
+    assert ssl_context.check_hostname is False
+    assert ssl_context.verify_mode is ssl.CERT_NONE
+
+
+async def test_sentinel_str_ssl_cert_optional():
+    ssl_context = ssl.create_default_context()
+    with mock_aioredis_sentinel() as mock_sentinel, \
+            mock.patch('ssl.create_default_context', return_value=ssl_context):
+        sentinel = Sentinel(
+            'rediss://:password@localhost:12345/2?'
+            'master=whatever&encoding=utf-8&ssl_cert_reqs=CERT_OPTIONAL',
+        )
+        assert await sentinel.get_master()
+    mock_sentinel.assert_called()
+    mock_sentinel.assert_called_with(
+        sentinels=[('localhost', 12345)],
+        db=2,
+        encoding='utf-8',
+        password='password',
+        minsize=1,
+        maxsize=100,
+        ssl=ssl_context
+    )
+    if sys.version_info < (3, 8, 0):
+        result = mock_sentinel.return_value.result()
+    else:
+        result = mock_sentinel.return_value
+    result.master_for.assert_called()
+    result.master_for.assert_called_with('whatever')
+    assert ssl_context.check_hostname is True
+    assert ssl_context.verify_mode is ssl.CERT_OPTIONAL
 
 
 async def test_sentinel_tuple():
@@ -100,15 +185,16 @@ async def test_sentinel_tuple():
         sentinel = Sentinel(
             ('127.0.0.1', 1234),
             master='blah',
+            ssl_context=False,
         )
         assert await sentinel.get_master()
-    assert mock_sentinel.called
-    mock_sentinel.assert_called_with(sentinels=[('127.0.0.1', 1234)], ssl=None)
+    mock_sentinel.assert_called()
+    mock_sentinel.assert_called_with(sentinels=[('127.0.0.1', 1234)], ssl=False, minsize=1, maxsize=100)
     if sys.version_info < (3, 8, 0):
         result = mock_sentinel.return_value.result()
     else:
         result = mock_sentinel.return_value
-    assert result.master_for.called
+    result.master_for.assert_called()
     result.master_for.assert_called_with('blah')
 
 
@@ -119,19 +205,24 @@ async def test_sentinel_list():
             master='blah',
         )
         assert await sentinel.get_master()
-    assert mock_sentinel.called
-    mock_sentinel.assert_called_with(sentinels=[('127.0.0.1', 1234), ('blah', 4829)], ssl=None)
+    mock_sentinel.assert_called()
+    mock_sentinel.assert_called_with(sentinels=[('127.0.0.1', 1234), ('blah', 4829)], minsize=1, maxsize=100)
     if sys.version_info < (3, 8, 0):
         result = mock_sentinel.return_value.result()
     else:
         result = mock_sentinel.return_value
-    assert result.master_for.called
+    result.master_for.assert_called()
     result.master_for.assert_called_with('blah')
 
 
 async def test_sentinel_no_master_specified():
     with pytest.raises(SentinelConfigError):
         Sentinel('redis://localhost:1234/0')
+
+
+async def test_sentinel_bad_database():
+    with pytest.raises(SentinelConfigError):
+        Sentinel('redis://localhost:1234/blah')
 
 
 async def test_sentinel_invalid_connection():


### PR DESCRIPTION
Sentinels handle the failover from one redis master to another based on
when a master node goes down, which should allow for seemless handling
of redis server problems.

Closes #74 
Closes #47 