### PR TITLE
Remove password from log output

### DIFF
--- a/aioredlock/algorithm.py
+++ b/aioredlock/algorithm.py
@@ -11,6 +11,7 @@ from aioredlock.lock import Lock
 from aioredlock.redis import Redis
 from aioredlock.utility import clean_password
 
+
 @attr.s
 class Aioredlock:
     redis_connections = attr.ib(

--- a/aioredlock/algorithm.py
+++ b/aioredlock/algorithm.py
@@ -9,12 +9,13 @@ import attr
 from aioredlock.errors import LockError
 from aioredlock.lock import Lock
 from aioredlock.redis import Redis
-
+from aioredlock.utility import clean_password
 
 @attr.s
 class Aioredlock:
-    redis_connections = attr.ib(default=[{'host': 'localhost', 'port': 6379}])
-
+    redis_connections = attr.ib(
+        default=[{"host": "localhost", "port": 6379}], repr=clean_password
+    )
     retry_count = attr.ib(default=3, converter=int)
     retry_delay_min = attr.ib(default=0.1, converter=float)
     retry_delay_max = attr.ib(default=0.3, converter=float)

--- a/aioredlock/redis.py
+++ b/aioredlock/redis.py
@@ -10,6 +10,7 @@ from aioredlock.errors import LockError
 from aioredlock.sentinel import Sentinel
 from aioredlock.utility import clean_password
 
+
 class Instance:
 
     # KEYS[1] - lock resource key

--- a/aioredlock/redis.py
+++ b/aioredlock/redis.py
@@ -8,7 +8,7 @@ import aioredis
 
 from aioredlock.errors import LockError
 from aioredlock.sentinel import Sentinel
-
+from aioredlock.utility import clean_password
 
 class Instance:
 
@@ -67,7 +67,8 @@ class Instance:
         return logging.getLogger(__name__)
 
     def __repr__(self):
-        return "<%s(connection='%s'>" % (self.__class__.__name__, self.connection)
+        connection_details = clean_password(self.connection)
+        return "<%s(connection='%s'>" % (self.__class__.__name__, connection_details)
 
     @staticmethod
     async def _create_redis_pool(*args, **kwargs):

--- a/aioredlock/utility.py
+++ b/aioredlock/utility.py
@@ -1,0 +1,15 @@
+import re
+
+REDIS_DSN_PATTERN = r"(redis:\/\/)(:.+@)?(.*)"
+
+
+def clean_password(details, cast=str):
+    if isinstance(details, dict):
+        details = {**details}
+        if "password" in details:
+            details["password"] = "*******"
+    elif isinstance(details, list):
+        details = [clean_password(x, cast=type(x)) for x in details]
+    elif isinstance(details, str) and re.match(REDIS_DSN_PATTERN, details):
+        details = re.sub(REDIS_DSN_PATTERN, "\\1:*******@\\3", details)
+    return cast(details)

--- a/tests/ut/test_utility.py
+++ b/tests/ut/test_utility.py
@@ -1,0 +1,51 @@
+import pytest
+from aioredlock.utility import clean_password
+
+
+def test_ignores_details_with_no_password():
+    details = {"foo": "bar"}
+    cleaned = clean_password(details)
+
+    assert str(details) == cleaned
+
+
+def test_cleans_details_with_password():
+    details = {"foo": "bar", "password": "topsecret"}
+    cleaned = clean_password(details)
+
+    assert cleaned == "{'foo': 'bar', 'password': '*******'}"
+
+
+def test_cleans_details_with_password_in_list():
+    details = [{"foo": "bar", "password": "topsecret"}]
+    cleaned = clean_password(details)
+
+    assert cleaned == "[{'foo': 'bar', 'password': '*******'}]"
+
+
+def test_ignores_non_dsn_string():
+    details = "Hello, world."
+    cleaned = clean_password(details)
+
+    assert details == cleaned
+
+
+@pytest.mark.parametrize(
+    "details",
+    [
+        "redis://someserver:1234/0",
+        "redis://:topsecret@someserver:1234/0",
+        "redis://:h8#iY60o$cqo@!39iaS&VI8tx@someserver:1234/0",
+    ],
+)
+def test_cleans_dsn_string(details):
+    cleaned = clean_password(details)
+
+    assert cleaned == "redis://:*******@someserver:1234/0"
+
+
+def test_cleans_dsn_string_in_list():
+    details = ["redis://:topsecret@someserver:1234/0"]
+    cleaned = clean_password(details)
+
+    assert cleaned == "['redis://:*******@someserver:1234/0']"


### PR DESCRIPTION
The `DEBUG` output leaks passwords to logs. This PR attempts to correct that.

Example output running `examples/basic_lock.py`:

```
DEBUG:asyncio:Using selector: EpollSelector
DEBUG:aioredlock.redis:Connecting <Instance(connection='{'host': 'localhost', 'port': 6666, 'db': 0, 'password': '*******'}'>
DEBUG:aioredis:Creating tcp connection to ('localhost', 6666)
DEBUG:aioredlock.algorithm:Acquiring lock "resource" try 1/3
DEBUG:aioredlock.redis:Lock "resource" is set on <Instance(connection='{'host': 'localhost', 'port': 6666, 'db': 0, 'password': '*******'}'>
DEBUG:aioredlock.redis:Lock "resource" is set on 1/1 instances in 0.0006810500053688884 seconds
DEBUG:aioredlock.algorithm:Releasing lock "resource"
DEBUG:aioredlock.redis:Lock "resource" is unset on <Instance(connection='{'host': 'localhost', 'port': 6666, 'db': 0, 'password': '*******'}'>
DEBUG:aioredlock.redis:Lock "resource" is unset on 1/1 instances in 0.0003751699987333268 seconds
DEBUG:aioredlock.algorithm:Destroying Aioredlock(redis_connections=[{'host': 'localhost', 'port': 6666, 'db': 0, 'password': '*******'}], retry_count=3, retry_delay_min=0.1, retry_delay_max=0.3, internal_lock_timeout=10.0)
DEBUG:aioredlock.redis:Clearing connection
DEBUG:aioredis:Closed 1 connection(s)
```

And...

```
DEBUG:asyncio:Using selector: EpollSelector
DEBUG:aioredlock.redis:Connecting <Instance(connection='redis://:*******@localhost:6666/0'>
DEBUG:aioredis:Creating tcp connection to ('localhost', 6666)
DEBUG:aioredlock.algorithm:Acquiring lock "resource" try 1/3
DEBUG:aioredlock.redis:Lock "resource" is set on <Instance(connection='redis://:*******@localhost:6666/0'>
DEBUG:aioredlock.redis:Lock "resource" is set on 1/1 instances in 0.0002706499944906682 seconds
DEBUG:aioredlock.algorithm:Releasing lock "resource"
DEBUG:aioredlock.redis:Lock "resource" is unset on <Instance(connection='redis://:*******@localhost:6666/0'>
DEBUG:aioredlock.redis:Lock "resource" is unset on 1/1 instances in 0.0002743399963947013 seconds
DEBUG:aioredlock.algorithm:Destroying Aioredlock(redis_connections=['redis://:*******@localhost:6666/0'], retry_count=3, retry_delay_min=0.1, retry_delay_max=0.3, internal_lock_timeout=10.0)
DEBUG:aioredlock.redis:Clearing connection
DEBUG:aioredis:Closed 1 connection(s)
```