### PR TITLE
feat(redis): Allow distinction between exceptions

### DIFF
--- a/aioredlock/__init__.py
+++ b/aioredlock/__init__.py
@@ -1,5 +1,5 @@
 from aioredlock.algorithm import Aioredlock
-from aioredlock.errors import LockError
+from aioredlock.errors import LockError, LockAcquiringError, LockRuntimeError
 from aioredlock.lock import Lock
 from aioredlock.sentinel import Sentinel
 
@@ -7,5 +7,7 @@ __all__ = (
     'Aioredlock',
     'Lock',
     'LockError',
+    'LockAcquiringError',
+    'LockRuntimeError',
     'Sentinel'
 )

--- a/aioredlock/errors.py
+++ b/aioredlock/errors.py
@@ -8,3 +8,15 @@ class LockError(AioredlockError):
     """
     Error in acquiring or releasing the lock
     """
+
+
+class LockAcquiringError(LockError):
+    """
+    Error in acquiring the lock during normal operation
+    """
+
+
+class LockRuntimeError(LockError):
+    """
+    Error in acquiring or releasing the lock due to an unexpected event
+    """

--- a/examples/basic_lock.py
+++ b/examples/basic_lock.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 
-from aioredlock import Aioredlock, LockError
+from aioredlock import Aioredlock, LockError, LockAcquiringError
 
 
 async def basic_lock():
@@ -17,9 +17,12 @@ async def basic_lock():
 
     try:
         lock = await lock_manager.lock("resource")
-    except LockError:
-        print('Something is wrong')
-        raise
+    except LockError as e:
+        if e.__cause__ and isinstance(e.__cause__, LockAcquiringError):
+            print('Something happened during normal operation')
+        else:
+            print('Something is really wrong and we prefer to raise the exception')
+            raise
     assert lock.valid is True
     assert await lock_manager.is_locked("resource") is True
 

--- a/examples/sentinel.py
+++ b/examples/sentinel.py
@@ -38,7 +38,7 @@ import logging
 
 import aiodocker
 
-from aioredlock import Aioredlock, LockError, Sentinel
+from aioredlock import Aioredlock, LockError, LockAcquiringError, Sentinel
 
 
 async def get_container(name):
@@ -84,10 +84,12 @@ async def lock_context():
             await container.unpause()
 
         assert lock.valid is False  # lock will be released by context manager
-    except LockError:
-        print('"resource" key might be not empty. Please call '
-              '"del resource" in redis-cli')
-        raise
+    except LockError as e:
+        if e.__cause__ and isinstance(e.__cause__, LockAcquiringError):
+            print('Something happened during normal operation')
+        else:
+            print('Something is really wrong and we prefer to raise the exception')
+            raise
 
     assert lock.valid is False
     assert await lock_manager.is_locked("resource") is False

--- a/tests/ut/test_redis.py
+++ b/tests/ut/test_redis.py
@@ -464,8 +464,10 @@ class TestRedis:
         if success:
             await method('resource', 'lock_id')
         else:
-            with pytest.raises(LockError):
+            with pytest.raises(LockError) as exc_info:
                 await method('resource', 'lock_id')
+            assert hasattr(exc_info.value, '__cause__')
+            assert isinstance(exc_info.value.__cause__, BaseException)
 
         script_sha1 = getattr(redis.instances[0],
                               '%s_script_sha1' % method_name)


### PR DESCRIPTION
This commit implements 2 things to enhance errors management.

1. It implements exceptions chaining in `Redis.set_lock`,
   `Redis.get_lock_ttl` and `Redis.unset_lock` so calling code of these
   methods is aware of the original exceptions that prevented the operation
   to complete.
2. It creates new exception types derived from `LockError` to distinguish
   between "normal operation" errors (if a lock is already acquired there's
   no need to raise an exception) and "real errors" like if something
   prevents us to connect to Redis

Closes #90.