### PR TITLE
feat(redis): Enhance exceptions usage

### DIFF
--- a/examples/basic_lock.py
+++ b/examples/basic_lock.py
@@ -17,12 +17,11 @@ async def basic_lock():
 
     try:
         lock = await lock_manager.lock("resource")
-    except LockError as e:
-        if e.__cause__ and isinstance(e.__cause__, LockAcquiringError):
-            print('Something happened during normal operation')
-        else:
-            print('Something is really wrong and we prefer to raise the exception')
-            raise
+    except LockAcquiringError:
+        print('Something happened during normal operation. We just log it.')
+    except LockError:
+        print('Something is really wrong and we prefer to raise the exception')
+        raise
     assert lock.valid is True
     assert await lock_manager.is_locked("resource") is True
 

--- a/examples/lock_context.py
+++ b/examples/lock_context.py
@@ -29,12 +29,11 @@ async def lock_context():
             # Do more stuff having the lock and if you spend much more time than you expected, the lock might be freed
 
         assert lock.valid is False  # lock will be released by context manager
-    except LockError as e:
-        if e.__cause__ and isinstance(e.__cause__, LockAcquiringError):
-            print('Something happened during normal operation')
-        else:
-            print('Something is really wrong and we prefer to raise the exception')
-            raise
+    except LockAcquiringError:
+        print('Something happened during normal operation. We just log it.')
+    except LockError:
+        print('Something is really wrong and we prefer to raise the exception')
+        raise
 
     assert lock.valid is False
     assert await lock_manager.is_locked("resource") is False

--- a/examples/sentinel.py
+++ b/examples/sentinel.py
@@ -84,12 +84,11 @@ async def lock_context():
             await container.unpause()
 
         assert lock.valid is False  # lock will be released by context manager
-    except LockError as e:
-        if e.__cause__ and isinstance(e.__cause__, LockAcquiringError):
-            print('Something happened during normal operation')
-        else:
-            print('Something is really wrong and we prefer to raise the exception')
-            raise
+    except LockAcquiringError:
+        print('Something happened during normal operation. We just log it.')
+    except LockError:
+        print('Something is really wrong and we prefer to raise the exception')
+        raise
 
     assert lock.valid is False
     assert await lock_manager.is_locked("resource") is False


### PR DESCRIPTION
In PR #93, I proposed to use exceptions chaining so we can use
`exception.__cause__` in the calling code to determine which original
exception occured and act upon.

But from a user's perspective, it's not easy to use at all.
What would be better is to raise specific exceptions we distinguished
in the previous commit so we can catch them with multiple `except`
statements in our calling code.

That's what this commit implements.
I've also updated usage examples to show the simplification.