### PR TITLE
fix(redis): Do not run unset_lock if destroy was called before

### DIFF
--- a/aioredlock/redis.py
+++ b/aioredlock/redis.py
@@ -395,6 +395,10 @@ class Redis:
         :raises: LockRuntimeError or LockAcquiringError or LockError if the lock has no
             matching identifier in more then (N/2 - 1) instances
         """
+
+        if not self.instances:
+            return .0
+
         start_time = time.monotonic()
 
         successes = await asyncio.gather(*[


### PR DESCRIPTION
As explained in [a comment] on another PR, there was an issue in the
following scenario:
- a resource is locked by A
- B tries to acquire the same resource but fail because it's already
  acquired
- on B, the code in `Aioredlock._set_lock()` catches the exception
  and schedules the `cleanup()` function that tries to `unset_lock`
  later
- but the calling code is using `try / finally` to call `destroy()`
  like:
  ```py
  try:
    lock = await lock_manager.lock("resource")
  finally:
    await lock_manager.destroy()
  ```

In this case, when the `cleanup()` function is executed, the instances
on the Redis class are already destroyed and locks were cleaned so there
is nothing to do. But the current conditions in `unset_lock()` were
making the code end up with this error:
```
ERROR:asyncio:Task exception was never retrieved
future: <Task finished name='Task-12'
coro=<Aioredlock._set_lock.<locals>.cleanup() done, defined at
/[...]/lib/python3.9/site-packages/aioredlock/algorithm.py:96>
exception=IndexError('list index out of range')>

Traceback (most recent call last):
  File "/[...]/lib/python3.9/site-packages/aioredlock/algorithm.py", line 99, in cleanup
    await self.redis.unset_lock(resource, lock_identifier)
  File "/[...]/lib/python3.9/site-packages/aioredlock/redis.py", line 417, in unset_lock
    raise_error(successes, 'Can not release the lock')
  File "/[...]/lib/python3.9/site-packages/aioredlock/redis.py", line 28, in raise_error
    raise LockError(default_message) from errors[0]
IndexError: list index out of range
```

It's easy to reproduce with the following diff on script `basic_lock` by
running it in parallel in two different terminals:
```diff
--- a/examples/basic_lock.py
+++ b/examples/basic_lock.py
@@ -17,21 +17,14 @@ async def basic_lock():

     try:
         lock = await lock_manager.lock("resource")
+        await asyncio.sleep(10)
     except LockAcquiringError:
         print('Something happened during normal operation. We just log it.')
     except LockError:
         print('Something is really wrong and we prefer to raise the exception')
         raise
-    assert lock.valid is True
-    assert await lock_manager.is_locked("resource") is True
-
-    # Do your stuff having the lock
-
-    await lock_manager.unlock(lock)
-    assert lock.valid is False
-    assert await lock_manager.is_locked("resource") is False
-
-    await lock_manager.destroy()
+    finally:
+        await lock_manager.destroy()

 if __name__ == "__main__":
```

[a comment]: https://github.com/joanvila/aioredlock/pull/93#discussion_r645548044