### PR TITLE
chore(deps): Lock aioredis to <2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=find_packages(),
 
     python_requires='>=3.6',
-    install_requires=['aioredis', 'attrs >= 17.4.0'],
+    install_requires=['aioredis<2', 'attrs >= 17.4.0'],
     extras_require={
         'test': ['pytest==6.1.0', 'pytest-asyncio', 'pytest-mock', 'pytest-cov', 'flake8'],
         'cicd': ['codecov'],


### PR DESCRIPTION
`aioredis` v2.0.0 has just been released:
https://pypi.org/project/aioredis/2.0.0/

It breaks `aioredlock` with the following errors:
```
AttributeError: module 'aioredis' has no attribute 'create_redis_pool'
AttributeError: module 'aioredis' has no attribute 'errors'
```

I propose to lock the `aioredis` version `aioredlock` requires to
<2 (latest before v2.0.0 is v1.3.1).